### PR TITLE
Fix 500 Internal server error bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@
 
 其他支持 Streamable HTTP 传输的 MCP 客户端同理，只需配置端点 URL。
 
+或者执行命令，例如：
+```
+claude mcp add --transport http jinguyuan-dumpling-skill https://mcp-4g9gkps4c04addd0.service.tcloudbase.com/jgy-mcp --header "Accept: application/json, text/event-stream"
+```
+或
+```
+kimi mcp add --transport http jinguyuan-dumpling-skill https://mcp-4g9gkps4c04addd0.service.tcloudbase.com/jgy-mcp --header "Accept: application/json, text/event-stream"
+```
+等。
+
 ## 发布平台
 
 - GitHub：https://github.com/JinGuYuan/jinguyuan-dumpling-skill


### PR DESCRIPTION
This pull request makes a small update to the `README.md` file, adding configuration options for the `jinguyuan-dumpling-skill` server. The new options specify the transport protocol and accepted headers for requests. 

- Added `transport: "http"` and a `headers` object with `Accept: "application/json, text/event-stream"` to the `jinguyuan-dumpling-skill` server configuration in `README.md`.